### PR TITLE
chore: bump third-party GH Actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961ead91fd16ce61f2bf # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Third-party sweep ahead of GitHub's Node 24 transition. The previous sweep covered the `actions/*` namespace; this one covers third-party actions that still ran on Node 20 (or older). Latest `gh api action.yml` runtime confirmed for each target version.

**Bumps:**
- `docker/build-push-action` v6 → v7.2.0
- `docker/login-action` v3 → v4.2.0
- `docker/metadata-action` v5 → v6.1.0

**Files:**
- `.github/workflows/docker.yml`

**Runtime audit (current pin → target pin):**
- `softprops/action-gh-release` v1 (Node 16!) / v2.x (Node 20) → v3.0.0 (Node 24)
- `astral-sh/setup-uv` v3 (Node 16!) / v5.x (Node 20) → v8.1.0 (Node 24)
- `pnpm/action-setup` v3 / v4 (Node 20) → v6.0.8 (Node 24)
- `docker/login-action` v3 (Node 20) → v4.2.0 (Node 24)
- `docker/build-push-action` v6 (Node 20) → v7.2.0 (Node 24)
- `docker/setup-buildx-action` v3 (Node 20) → v4.1.0 (Node 24)
- `docker/setup-qemu-action` v3.x (Node 20) → v4.0.0 (Node 24)
- `docker/metadata-action` v5 (Node 20) → v6.1.0 (Node 24)

Only the action versions you have pinned are bumped — `pnpm/action-setup@v5`, `docker/login-action@v4*`, etc. already run on Node 24 and are left alone.

**SHA + version-comment pinning convention preserved.** All pins remain hard-pinned to commit SHA with `# vX.Y.Z` comment, matching the org's supply-chain hardening style.
