### PR TITLE
ci: rename publish.yml → release.yml (match npm TP) + ship npm translations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Release
 
 on:
   release:
@@ -34,13 +34,11 @@ jobs:
         with:
           print-hash: true
 
-  # npm launcher (@mcptoolshop/audiobooker). Dormant until the package name is
-  # reserved (placeholder publish) and a Trusted Publisher is configured on
-  # npmjs.com bound to this workflow file. Then set repo variable
-  # NPM_PUBLISH_ENABLED=true to activate it on the next release.
+  # npm launcher (@mcptoolshop/audiobooker). Publishes via the Trusted Publisher
+  # configured on npmjs.com (GitHub Actions, this repo, workflow release.yml).
+  # The tag-vs-package.json check below guards against version drift.
   publish-npm:
     name: Publish npm launcher
-    if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ CRITICAL/HIGH finding was cross-verified by an independent (non-Claude) model.
 
 ### Security
 
-- `publish.yml` gains a protected `pypi` GitHub Environment for OIDC publishing.
+- Release workflow (`release.yml`, renamed from `publish.yml`) publishes both PyPI (`audiobooker-ai`, protected `pypi` environment) and the npm launcher via OIDC Trusted Publishing.
 - GitHub Actions on Node-24-compatible releases; `docker/login-action` v4.
 
 ## [2.0.1] - 2026-04-23

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ When testing with real books:
 2. Update CHANGELOG.md
 3. Create git tag: `git tag v2.x.x`
 4. Push tag: `git push origin v2.x.x`
-5. GitHub Actions publishes to PyPI via trusted publishing (`.github/workflows/publish.yml`)
+5. GitHub Actions publishes to PyPI + npm via trusted publishing (`.github/workflows/release.yml`)
 6. Docker image is built and pushed to GHCR (`.github/workflows/docker.yml`)
 
 ## Code of Conduct

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,6 +14,7 @@
   "files": [
     "bin/",
     "README.md",
+    "README.*.md",
     "LICENSE"
   ],
   "repository": {


### PR DESCRIPTION
The npm Trusted Publisher (just configured) is bound to **`release.yml`**, but the npm-publish job was in `publish.yml` — that filename mismatch fails the OIDC handshake at publish time. This renames the workflow to `release.yml` (also the org convention) so PyPI + npm both publish from it on a release, and removes the now-redundant `NPM_PUBLISH_ENABLED` gate.

Also: `npm/package.json` `files` now includes `README.*.md`, so the launcher package ships its 7 README translations in the tarball (logo is referenced by raw GitHub URL → renders on npm).

**Note:** the PyPI Trusted Publisher should also point at `release.yml` (it was never exercised — no release has been cut yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)