### PR TITLE
fix(ci): correct gh-action-pypi-publish SHA (PyPI publish failed on v2.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI (trusted publishing / OIDC)
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54f72e44af12044e8c37755 # v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           print-hash: true
 
@@ -39,6 +39,9 @@ jobs:
   # The tag-vs-package.json check below guards against version drift.
   publish-npm:
     name: Publish npm launcher
+    # Only on a real release — npm rejects republishing an existing version, and
+    # the tag-vs-package.json check needs a vX.Y.Z ref (not a workflow_dispatch).
+    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The pinned SHA for `pypa/gh-action-pypi-publish` was corrupted (`76f52bc...755` doesn't exist; real v1.12.4 is `76f52bc...dfc`), so the PyPI job on the v2.1.0 release couldn't resolve the action.

**npm published fine** — `@mcptoolshop/audiobooker` 2.1.0 is live. This fixes the SHA and gates the npm job to release events so a `workflow_dispatch` re-run (to publish PyPI 2.1.0) doesn't re-fail on the already-published npm version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)